### PR TITLE
Merge Development: Update Adsense script loading strategy to lazyOnload

### DIFF
--- a/src/components/adsense.tsx
+++ b/src/components/adsense.tsx
@@ -7,7 +7,7 @@ export default function Adsense() {
       src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${process
         .env.NEXT_PUBLIC_ADSENSE_PUB_ID!}`}
       crossOrigin="anonymous"
-      strategy="afterInteractive"
+      strategy="lazyOnload"
     ></Script>
   );
 }


### PR DESCRIPTION
## Overview
This PR updates the Google AdSense script loading strategy to `lazyOnload`. This change aims to improve the page load performance by deferring the loading of the AdSense script until the window's `load` event fires. This strategy ensures that the script does not interfere with the critical rendering path, leading to faster page load times and a better user experience.

## Changes
- Modified the AdSense script inclusion to trigger on window's `load` event.